### PR TITLE
feat: Add HTTPClient.patch() for sending PATCH requests

### DIFF
--- a/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
+++ b/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
@@ -82,6 +82,15 @@ public class HTTPClient {
         }
     }
 
+    public func patch(url: String, body: Body? = nil, timeout: Timeout? = nil) -> EventLoopFuture<Response> {
+        do {
+            let request = try HTTPClient.Request(url: url, method: .PATCH, body: body)
+            return self.execute(request: request)
+        } catch {
+            return self.group.next().makeFailedFuture(error)
+        }
+    }
+
     public func put(url: String, body: Body? = nil, timeout: Timeout? = nil) -> EventLoopFuture<Response> {
         do {
             let request = try HTTPClient.Request(url: url, method: .PUT, body: body)


### PR DESCRIPTION
`PATCH` is a commonly supported verb in RESTful APIs. Although it is
already possible to send a PATCH request via the `HTTPClient.execute()`
API this commit adds an explicit `patch()` API for consistency.

This gives us explicit APIs for `GET`, `POST`, `PUT`, `PATCH` and
`DELETE`.