### PR TITLE
Add 'Show on GitHub' link to API docs

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -57,6 +57,7 @@ jazzy_args=(--clean
             --readme "$module_switcher"
             --author_url https://github.com/swift-server/swift-nio-http-client
             --github_url https://github.com/swift-server/swift-nio-http-client
+            --github-file-prefix https://github.com/swift-server/swift-nio-http-client/tree/$version
             --theme fullwidth
             --xcodebuild-arguments -scheme,swift-nio-http-client-Package)
 cat > "$module_switcher" <<"EOF"


### PR DESCRIPTION
Motivation:

Allowing readers of the API documentation to drill into the implementation of documented declarations can be educational and helpful for debugging, among several other reasons.

Modifications:

Add --github-file-prefix appending the current version in order to keep stable links. This means that documentation generated from any non-release revision may resolve incorrectly. This can be refined in the doc generation script later if it is deemed problematic by resolving to the commit sha if it doesn't exactly align with the version.

Result:

Users will be able to click a 'Show on GitHub' for all documented API declarations.