### PR TITLE
Transfer scheme and host to new request when redirected

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         ),
         .testTarget(
             name: "NIOHTTPClientTests",
-            dependencies: ["NIOHTTPClient"]
+            dependencies: ["NIOHTTPClient", "NIOFoundationCompat"]
         ),
     ]
 )

--- a/Sources/NIOHTTPClient/HTTPClientProxyHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPClientProxyHandler.swift
@@ -74,7 +74,7 @@ internal final class HTTPClientProxyHandler: ChannelDuplexHandler, RemovableChan
             switch res {
             case .head(let head):
                 switch head.status.code {
-                case 200..<300:
+                case 200 ..< 300:
                     // Any 2xx (Successful) response indicates that the sender (and all
                     // inbound proxies) will switch to tunnel mode immediately after the
                     // blank line that concludes the successful response's header section
@@ -116,7 +116,7 @@ internal final class HTTPClientProxyHandler: ChannelDuplexHandler, RemovableChan
     private func handleConnect(context: ChannelHandlerContext) -> EventLoopFuture<Void> {
         return self.onConnect(context.channel).flatMap {
             self.readState = .connected
-            
+
             // forward any buffered reads
             while !self.readBuffer.isEmpty {
                 context.fireChannelRead(self.readBuffer.removeFirst())

--- a/Sources/NIOHTTPClient/HTTPCookie.swift
+++ b/Sources/NIOHTTPClient/HTTPCookie.swift
@@ -68,7 +68,7 @@ public struct HTTPCookie {
                 formatter.locale = Locale(identifier: "en_US")
                 formatter.timeZone = TimeZone(identifier: "GMT")
                 formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
-                self.expires = parseComponentValue(component).flatMap { formatter.date(from: $0) }
+                self.expires = self.parseComponentValue(component).flatMap { formatter.date(from: $0) }
                 continue
             }
 

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -442,8 +442,19 @@ internal struct RedirectHandler<T> {
 
         var request = self.request
         request.url = redirectURL
-        request.host = redirectURL.host!
-        request.scheme = redirectURL.scheme!
+        
+        if let redirectHost = redirectURL.host {
+            request.host = redirectHost
+        } else {
+            assertionFailure("redirectURL doesn't contain a host")
+        }
+        
+        if let redirectScheme = redirectURL.scheme {
+            request.scheme = redirectScheme
+        } else {
+            assertionFailure("redirectURL doesn't contain a scheme")
+        }
+
 
         var convertToGet = false
         if status == .seeOther, request.method != .HEAD {

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -446,13 +446,13 @@ internal struct RedirectHandler<T> {
         if let redirectHost = redirectURL.host {
             request.host = redirectHost
         } else {
-            assertionFailure("redirectURL doesn't contain a host")
+            preconditionFailure("redirectURL doesn't contain a host")
         }
 
         if let redirectScheme = redirectURL.scheme {
             request.scheme = redirectScheme
         } else {
-            assertionFailure("redirectURL doesn't contain a scheme")
+            preconditionFailure("redirectURL doesn't contain a scheme")
         }
 
         var convertToGet = false

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -442,6 +442,8 @@ internal struct RedirectHandler<T> {
 
         var request = self.request
         request.url = redirectURL
+        request.host = redirectURL.host!
+        request.scheme = redirectURL.scheme!
 
         var convertToGet = false
         if status == .seeOther, request.method != .HEAD {

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -442,19 +442,18 @@ internal struct RedirectHandler<T> {
 
         var request = self.request
         request.url = redirectURL
-        
+
         if let redirectHost = redirectURL.host {
             request.host = redirectHost
         } else {
             assertionFailure("redirectURL doesn't contain a host")
         }
-        
+
         if let redirectScheme = redirectURL.scheme {
             request.scheme = redirectScheme
         } else {
             assertionFailure("redirectURL doesn't contain a scheme")
         }
-
 
         var convertToGet = false
         if status == .seeOther, request.method != .HEAD {

--- a/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
+++ b/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
@@ -116,7 +116,7 @@ public class HTTPClient {
     public func execute<T: HTTPClientResponseDelegate>(request: Request, delegate: T, timeout: Timeout? = nil) -> Task<T.Response> {
         let timeout = timeout ?? configuration.timeout
         let promise: EventLoopPromise<T.Response> = self.eventLoopGroup.next().makePromise()
-        
+
         let redirectHandler: RedirectHandler<T.Response>?
         if self.configuration.followRedirects {
             redirectHandler = RedirectHandler<T.Response>(request: request) { newRequest in

--- a/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
@@ -224,6 +224,20 @@ internal final class HttpBinHandler: ChannelInboundHandler {
                 headers.add(name: "Location", value: "https://localhost:\(port)/ok")
                 self.resps.append(HTTPResponseBuilder(status: .found, headers: headers))
                 return
+            case "/redirect/loopback":
+                let port = self.value(for: "port", from: url.query!)
+                var headers = HTTPHeaders()
+                headers.add(name: "Location", value: "http://127.0.0.1:\(port)/echohostheader")
+                self.resps.append(HTTPResponseBuilder(status: .found, headers: headers))
+                return
+            case "/echohostheader":
+                var builder = HTTPResponseBuilder(status: .ok)
+                let hostValue = req.headers["Host"].first ?? ""
+                var buff = context.channel.allocator.buffer(capacity: hostValue.utf8.count)
+                buff.writeString(hostValue)
+                builder.add(buff)
+                self.resps.append(builder)
+                return
             case "/wait":
                 return
             case "/close":

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests+XCTest.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests+XCTest.swift
@@ -33,6 +33,7 @@ extension SwiftHTTPTests {
             ("testGetHttps", testGetHttps),
             ("testPostHttps", testPostHttps),
             ("testHttpRedirect", testHttpRedirect),
+            ("testHttpHostRedirect", testHttpHostRedirect),
             ("testMultipleContentLengthHeaders", testMultipleContentLengthHeaders),
             ("testStreaming", testStreaming),
             ("testRemoteClose", testRemoteClose),

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
@@ -169,6 +169,17 @@ class SwiftHTTPTests: XCTestCase {
 
         response = try httpClient.get(url: "http://localhost:\(httpBin.port)/redirect/https?port=\(httpsBin.port)").wait()
         XCTAssertEqual(response.status, .ok)
+        
+        response = try httpClient.get(url: "https://httpbin.org/redirect-to?url=https%3A%2F%2Fwww.httpbin.org%2Fheaders").wait()
+        guard let body = response.body else {
+            XCTFail("The target page should have a body containing request headers")
+            return
+        }
+        let data = body.withUnsafeReadableBytes {
+            Data(bytes: $0.baseAddress!, count: $0.count)
+        }
+        let jsonData = try JSONSerialization.jsonObject(with: data, options: [])
+        XCTAssert((jsonData as? [String:[String:String]])?["headers"]?["Host"] == "www.httpbin.org")
     }
 
     func testMultipleContentLengthHeaders() throws {

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
@@ -17,6 +17,7 @@ import NIO
 @testable import NIOHTTP1
 @testable import NIOHTTPClient
 import NIOSSL
+import NIOFoundationCompat
 import XCTest
 
 class SwiftHTTPTests: XCTestCase {
@@ -180,12 +181,13 @@ class SwiftHTTPTests: XCTestCase {
         }
 
         let response = try httpClient.get(url: "https://httpbin.org/redirect-to?url=https%3A%2F%2Fwww.httpbin.org%2Fheaders").wait()
-        guard let body = response.body else {
+        guard var body = response.body else {
             XCTFail("The target page should have a body containing request headers")
             return
         }
-        let data = body.withUnsafeReadableBytes {
-            Data(bytes: $0.baseAddress!, count: $0.count)
+        guard let data = body.readData(length: body.readableBytes) else {
+            XCTFail("Read data shouldn't return nil as it has been passed readableBytes")
+            return
         }
 
         let decoder = JSONDecoder()

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
@@ -170,15 +170,15 @@ class SwiftHTTPTests: XCTestCase {
         response = try httpClient.get(url: "http://localhost:\(httpBin.port)/redirect/https?port=\(httpsBin.port)").wait()
         XCTAssertEqual(response.status, .ok)
     }
-    
+
     func testHttpHostRedirect() throws {
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew,
                                     configuration: HTTPClient.Configuration(certificateVerification: .none, followRedirects: true))
-        
+
         defer {
             try! httpClient.syncShutdown()
         }
-        
+
         let response = try httpClient.get(url: "https://httpbin.org/redirect-to?url=https%3A%2F%2Fwww.httpbin.org%2Fheaders").wait()
         guard let body = response.body else {
             XCTFail("The target page should have a body containing request headers")
@@ -187,13 +187,13 @@ class SwiftHTTPTests: XCTestCase {
         let data = body.withUnsafeReadableBytes {
             Data(bytes: $0.baseAddress!, count: $0.count)
         }
-        
+
         let decoder = JSONDecoder()
         struct HeadersContainer: Decodable {
-            var headers: [String:String]
+            var headers: [String: String]
         }
         let host = try decoder.decode(HeadersContainer.self, from: data).headers["Host"]
-        
+
         XCTAssert(host == "www.httpbin.org")
     }
 


### PR DESCRIPTION
This solves a bug that could cause infinite redirections (eg: requesting example.com, being redirected to www.example.com, but requesting again example.com as host hadn't been correctly modified).