### PR TITLE
Solve incorrect "Show on GitHub" link

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -17,7 +17,7 @@ set -e
 
 my_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 root_path="$my_path/.."
-version=$(git describe --abbrev=0 --tags || echo "0.0.0")
+version=$(git describe --abbrev=0 --tags || echo "master")
 modules=(NIOHTTPClient)
 
 if [[ "$(uname -s)" == "Linux" ]]; then
@@ -51,13 +51,14 @@ fi
 if ! command -v jazzy > /dev/null; then
   gem install jazzy --no-ri --no-rdoc
 fi
+
 module_switcher="docs/$version/README.md"
 jazzy_args=(--clean
             --author 'SwiftNIOHTTPClient team'
             --readme "$module_switcher"
             --author_url https://github.com/swift-server/swift-nio-http-client
             --github_url https://github.com/swift-server/swift-nio-http-client
-            --github-file-prefix https://github.com/swift-server/swift-nio-http-client/tree/$version
+            --github-file-prefix "https://github.com/swift-server/swift-nio-http-client/tree/$version"
             --theme fullwidth
             --xcodebuild-arguments -scheme,swift-nio-http-client-Package)
 cat > "$module_switcher" <<"EOF"


### PR DESCRIPTION
Since the package isn't tagged yet, the current file prefix URL isn't valid, causing the declarations "Go to GitHub" button to lead to a 404 page.