### PR TITLE
Upload streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,15 @@ class CountingDelegate: HTTPResponseDelegate {
 
     var count = 0
 
-    func didTransmitRequestPart(task: HTTPClient.Task<Response>, _ part: IOData) {
+    func didSendRequestHead(task: HTTPClient.Task<Response>, _ head: HTTPRequestHead) {
+        // this is executed right after request head was sent, called once
+    }
+
+    func didSendRequestPart(task: HTTPClient.Task<Response>, _ part: IOData) {
         // this is executed when request body part is sent, could be called zero or more times
     }
 
-    func didTransmitRequest(task: HTTPClient.Task<Response>) {
+    func didSendRequest(task: HTTPClient.Task<Response>) {
         // this is executed when request is fully sent, called once
     }
 

--- a/README.md
+++ b/README.md
@@ -116,28 +116,28 @@ class CountingDelegate: HTTPResponseDelegate {
 
     var count = 0
 
-    func didTransmitRequestBody() {
+    func didTransmitRequestBody(task: HTTPClient.Task<Response>) {
         // this is executed when request is sent, called once
     }
 
-    func didReceiveHead(_ head: HTTPResponseHead) {
+    func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) {
         // this is executed when we receive HTTP Reponse head part of the request (it contains response code and headers), called once
     }
 
-    func didReceivePart(_ buffer: ByteBuffer) -> EventLoopFuture<Void>? {
+    func didReceivePart(task: HTTPClient.Task<Response>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         // this is executed when we receive parts of the response body, could be called zero or more times
         count += buffer.readableBytes
-        // in case backpressure is needed, EventLoopFuture could be returned, all reads will be paused until this future is resolved
-        return nil
+        // in case backpressure is needed, all reads will be paused until returned future is resolved
+        return eventLoop.makeSucceededFuture(())
     }
 
-    func didFinishRequest() throws -> Int {
+    func didFinishRequest(task: HTTPClient.Task<Response>) throws -> Int {
         // this is called when the request is fully read, called once
         // this is where you return a result or throw any errors you require to propagate to the client
         return count
     }
 
-    func didReceiveError(_ error: Error) {
+    func didReceiveError(task: HTTPClient.Task<Response>, _ error: Error) {
         // this is called when we receive any network-related error, called once
     }
 }

--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ class CountingDelegate: HTTPResponseDelegate {
         // this is executed when request is fully sent, called once
     }
 
-    func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) {
+    func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
         // this is executed when we receive HTTP Reponse head part of the request (it contains response code and headers), called once
+        // in case backpressure is needed, all reads will be paused until returned future is resolved
+        return task.eventLoop.makeSucceededFuture(())
     }
 
     func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ class CountingDelegate: HTTPResponseDelegate {
         // this is executed when we receive HTTP Reponse head part of the request (it contains response code and headers), called once
     }
 
-    func didReceivePart(task: HTTPClient.Task<Response>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
+    func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         // this is executed when we receive parts of the response body, could be called zero or more times
         count += buffer.readableBytes
         // in case backpressure is needed, all reads will be paused until returned future is resolved
-        return eventLoop.makeSucceededFuture(())
+        return task.eventLoop.makeSucceededFuture(())
     }
 
     func didFinishRequest(task: HTTPClient.Task<Response>) throws -> Int {

--- a/README.md
+++ b/README.md
@@ -116,8 +116,12 @@ class CountingDelegate: HTTPResponseDelegate {
 
     var count = 0
 
-    func didTransmitRequestBody(task: HTTPClient.Task<Response>) {
-        // this is executed when request is sent, called once
+    func didTransmitRequestPart(task: HTTPClient.Task<Response>, _ part: IOData) {
+        // this is executed when request body part is sent, could be called zero or more times
+    }
+
+    func didTransmitRequest(task: HTTPClient.Task<Response>) {
+        // this is executed when request is fully sent, called once
     }
 
     func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) {

--- a/README.md
+++ b/README.md
@@ -124,9 +124,11 @@ class CountingDelegate: HTTPResponseDelegate {
         // this is executed when we receive HTTP Reponse head part of the request (it contains response code and headers), called once
     }
 
-    func didReceivePart(_ buffer: ByteBuffer) {
+    func didReceivePart(_ buffer: ByteBuffer) -> EventLoopFuture<Void>? {
         // this is executed when we receive parts of the response body, could be called zero or more times
         count += buffer.readableBytes
+        // in case backpressure is needed, EventLoopFuture could be returned, all reads will be paused until this future is resolved
+        return nil
     }
 
     func didFinishRequest() throws -> Int {

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -19,7 +19,7 @@ import NIOHTTP1
 import NIOSSL
 
 public extension HTTPClient {
-    typealias ChunkProvider = (@escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>
+    typealias ChunkProvider = (@escaping (IOData) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>
 
     enum Body {
         case byteBuffer(ByteBuffer)
@@ -342,7 +342,7 @@ internal class TaskHandler<T: HTTPClientResponseDelegate>: ChannelInboundHandler
                 return context.eventLoop.makeSucceededFuture(())
             case .stream(_, let stream):
                 return stream { part in
-                    let part = HTTPClientRequestPart.body(.byteBuffer(part))
+                    let part = HTTPClientRequestPart.body(part)
                     context.write(self.wrapOutboundOut(part), promise: nil)
                     return context.eventLoop.makeSucceededFuture(())
                 }

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -19,11 +19,11 @@ import NIOHTTP1
 import NIOSSL
 
 public extension HTTPClient {
-    typealias ChunkProvider = (@escaping (IOData) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>
-
     struct Body {
+        typealias ChunkProvider = (@escaping (IOData) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>
+
         var length: Int?
-        var provider: HTTPClient.ChunkProvider
+        var provider: ChunkProvider
 
         static func byteBuffer(_ buffer: ByteBuffer) -> Body {
             return Body(length: buffer.readableBytes) { writer in
@@ -31,7 +31,7 @@ public extension HTTPClient {
             }
         }
 
-        static func stream(length: Int? = nil, _ provider: @escaping HTTPClient.ChunkProvider) -> Body {
+        static func stream(length: Int? = nil, _ provider: @escaping ChunkProvider) -> Body {
             return Body(length: length, provider: provider)
         }
 

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -18,24 +18,22 @@ import NIOConcurrencyHelpers
 import NIOHTTP1
 import NIOSSL
 
-public extension HTTPClient {
-    struct Body {
-        typealias ChunkProvider = (@escaping (IOData) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>
+extension HTTPClient {
+    public struct Body {
+        public var length: Int?
+        public var provider: (@escaping (IOData) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>
 
-        var length: Int?
-        var provider: ChunkProvider
-
-        static func byteBuffer(_ buffer: ByteBuffer) -> Body {
+        public static func byteBuffer(_ buffer: ByteBuffer) -> Body {
             return Body(length: buffer.readableBytes) { writer in
                 writer(.byteBuffer(buffer))
             }
         }
 
-        static func stream(length: Int? = nil, _ provider: @escaping ChunkProvider) -> Body {
+        public static func stream(length: Int? = nil, _ provider: @escaping (@escaping (IOData) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>) -> Body {
             return Body(length: length, provider: provider)
         }
 
-        static func data(_ data: Data) -> Body {
+        public static func data(_ data: Data) -> Body {
             return Body(length: data.count) { writer in
                 var buffer = ByteBufferAllocator().buffer(capacity: data.count)
                 buffer.writeBytes(data)
@@ -43,7 +41,7 @@ public extension HTTPClient {
             }
         }
 
-        static func string(_ string: String) -> Body {
+        public static func string(_ string: String) -> Body {
             return Body(length: string.utf8.count) { writer in
                 var buffer = ByteBufferAllocator().buffer(capacity: string.utf8.count)
                 buffer.writeString(string)
@@ -52,7 +50,7 @@ public extension HTTPClient {
         }
     }
 
-    struct Request {
+    public struct Request {
         public var version: HTTPVersion
         public var method: HTTPMethod
         public var url: URL
@@ -104,7 +102,7 @@ public extension HTTPClient {
         }
     }
 
-    struct Response {
+    public struct Response {
         public var host: String
         public var status: HTTPResponseStatus
         public var headers: HTTPHeaders
@@ -224,7 +222,7 @@ internal extension URL {
 
 public extension HTTPClient {
     final class Task<Response> {
-        let eventLoop: EventLoop
+        public let eventLoop: EventLoop
         let future: EventLoopFuture<Response>
 
         private var channel: Channel?

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -285,7 +285,7 @@ internal class TaskHandler<T: HTTPClientResponseDelegate>: ChannelInboundHandler
 
     var state: State = .idle
     var pendingRead = false
-    var mayRead: Bool = true
+    var mayRead = true
 
     init(task: HTTPClient.Task<T.Response>, delegate: T, promise: EventLoopPromise<T.Response>, redirectHandler: RedirectHandler<T.Response>?) {
         self.task = task
@@ -344,7 +344,7 @@ internal class TaskHandler<T: HTTPClientResponseDelegate>: ChannelInboundHandler
     private func writeBody(request: HTTPClient.Request, context: ChannelHandlerContext) -> EventLoopFuture<Void> {
         if let body = request.body {
             return body.provider { part in
-                context.writeAndFlush(self.wrapOutboundOut(HTTPClientRequestPart.body(part)))
+                context.writeAndFlush(self.wrapOutboundOut(.body(part)))
             }
         } else {
             return context.eventLoop.makeSucceededFuture(())

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -128,8 +128,6 @@ internal class ResponseAccumulator: HTTPClientResponseDelegate {
         self.request = request
     }
 
-    func didTransmitRequestBody(task: HTTPClient.Task<Response>) {}
-
     func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) {
         switch self.state {
         case .idle:

--- a/Sources/NIOHTTPClient/RequestValidation.swift
+++ b/Sources/NIOHTTPClient/RequestValidation.swift
@@ -35,11 +35,17 @@ extension HTTPHeaders {
             }
 
             if encodings.isEmpty {
-                contentLength = body.length
+                guard let length = body.length else {
+                    throw HTTPClientError.contentLengthMissing
+                }
+                contentLength = length
             } else {
                 transferEncoding = encodings.joined(separator: ", ")
                 if !encodings.contains("chunked") {
-                    contentLength = body.length
+                    guard let length = body.length else {
+                        throw HTTPClientError.contentLengthMissing
+                    }
+                    contentLength = length
                 }
             }
         } else {

--- a/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
+++ b/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
@@ -256,6 +256,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
         case identityCodingIncorrectlyPresent
         case chunkedSpecifiedMultipleTimes
         case invalidProxyResponse
+        case contentLengthMissing
     }
 
     private var code: Code
@@ -279,4 +280,5 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     public static let identityCodingIncorrectlyPresent = HTTPClientError(code: .identityCodingIncorrectlyPresent)
     public static let chunkedSpecifiedMultipleTimes = HTTPClientError(code: .chunkedSpecifiedMultipleTimes)
     public static let invalidProxyResponse = HTTPClientError(code: .invalidProxyResponse)
+    public static let contentLengthMissing = HTTPClientError(code: .contentLengthMissing)
 }

--- a/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
+++ b/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
@@ -115,7 +115,8 @@ public class HTTPClient {
 
     public func execute<T: HTTPClientResponseDelegate>(request: Request, delegate: T, timeout: Timeout? = nil) -> Task<T.Response> {
         let timeout = timeout ?? configuration.timeout
-        let promise: EventLoopPromise<T.Response> = self.eventLoopGroup.next().makePromise()
+        let eventLoop = self.eventLoopGroup.next()
+        let promise: EventLoopPromise<T.Response> = eventLoop.makePromise()
 
         let redirectHandler: RedirectHandler<T.Response>?
         if self.configuration.followRedirects {
@@ -126,7 +127,7 @@ public class HTTPClient {
             redirectHandler = nil
         }
 
-        let task = Task(future: promise.futureResult)
+        let task = Task(eventLoop: eventLoop, future: promise.futureResult)
 
         var bootstrap = ClientBootstrap(group: self.eventLoopGroup)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)

--- a/Sources/NIOHTTPClient/Utils.swift
+++ b/Sources/NIOHTTPClient/Utils.swift
@@ -25,10 +25,11 @@ public class HandlingHTTPResponseDelegate<T>: HTTPClientResponseDelegate {
     var handleError: ((Error) -> Void)?
     var handleEnd: (() throws -> T)?
 
-    public func didReceiveHead(task: HTTPClient.Task<T>, _ head: HTTPResponseHead) {
+    public func didReceiveHead(task: HTTPClient.Task<T>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
         if let handler = handleHead {
             handler(head)
         }
+        return task.eventLoop.makeSucceededFuture(())
     }
 
     public func didReceivePart(task: HTTPClient.Task<T>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {

--- a/Sources/NIOHTTPClient/Utils.swift
+++ b/Sources/NIOHTTPClient/Utils.swift
@@ -33,11 +33,11 @@ public class HandlingHTTPResponseDelegate<T>: HTTPClientResponseDelegate {
         }
     }
 
-    public func didReceivePart(task: HTTPClient.Task<T>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
+    public func didReceivePart(task: HTTPClient.Task<T>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         if let handler = handleBody {
             handler(buffer)
         }
-        return eventLoop.makeSucceededFuture(())
+        return task.eventLoop.makeSucceededFuture(())
     }
 
     public func didReceiveError(task: HTTPClient.Task<T>, _ error: Error) {
@@ -63,7 +63,7 @@ final class CopyingDelegate: HTTPClientResponseDelegate {
         self.chunkHandler = chunkHandler
     }
 
-    func didReceivePart(task: HTTPClient.Task<Void>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
+    func didReceivePart(task: HTTPClient.Task<Void>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         return self.chunkHandler(buffer)
     }
 

--- a/Sources/NIOHTTPClient/Utils.swift
+++ b/Sources/NIOHTTPClient/Utils.swift
@@ -54,7 +54,7 @@ public class HandlingHTTPResponseDelegate<T>: HTTPClientResponseDelegate {
     }
 }
 
-class CopyingDelegate: HTTPClientResponseDelegate {
+final class CopyingDelegate: HTTPClientResponseDelegate {
     public typealias Response = Void
 
     let chunkHandler: (ByteBuffer) -> EventLoopFuture<Void>

--- a/Sources/NIOHTTPClient/Utils.swift
+++ b/Sources/NIOHTTPClient/Utils.swift
@@ -33,10 +33,11 @@ public class HandlingHTTPResponseDelegate<T>: HTTPClientResponseDelegate {
         }
     }
 
-    public func didReceivePart(task: HTTPClient.Task<T>, _ buffer: ByteBuffer) {
+    public func didReceivePart(task: HTTPClient.Task<T>, _ buffer: ByteBuffer) -> EventLoopFuture<Void>? {
         if let handler = handleBody {
             handler(buffer)
         }
+        return nil
     }
 
     public func didReceiveError(task: HTTPClient.Task<T>, _ error: Error) {

--- a/Sources/NIOHTTPClient/Utils.swift
+++ b/Sources/NIOHTTPClient/Utils.swift
@@ -33,11 +33,11 @@ public class HandlingHTTPResponseDelegate<T>: HTTPClientResponseDelegate {
         }
     }
 
-    public func didReceivePart(task: HTTPClient.Task<T>, _ buffer: ByteBuffer) -> EventLoopFuture<Void>? {
+    public func didReceivePart(task: HTTPClient.Task<T>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         if let handler = handleBody {
             handler(buffer)
         }
-        return nil
+        return eventLoop.makeSucceededFuture(())
     }
 
     public func didReceiveError(task: HTTPClient.Task<T>, _ error: Error) {
@@ -63,7 +63,7 @@ final class CopyingDelegate: HTTPClientResponseDelegate {
         self.chunkHandler = chunkHandler
     }
 
-    func didReceivePart(task: HTTPClient.Task<Void>, _ buffer: ByteBuffer) -> EventLoopFuture<Void>? {
+    func didReceivePart(task: HTTPClient.Task<Void>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         return self.chunkHandler(buffer)
     }
 

--- a/Sources/NIOHTTPClient/Utils.swift
+++ b/Sources/NIOHTTPClient/Utils.swift
@@ -25,8 +25,6 @@ public class HandlingHTTPResponseDelegate<T>: HTTPClientResponseDelegate {
     var handleError: ((Error) -> Void)?
     var handleEnd: (() throws -> T)?
 
-    public func didTransmitRequestBody(task: HTTPClient.Task<T>) {}
-
     public func didReceiveHead(task: HTTPClient.Task<T>, _ head: HTTPResponseHead) {
         if let handler = handleHead {
             handler(head)

--- a/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
@@ -23,8 +23,9 @@ class TestHTTPDelegate: HTTPClientResponseDelegate {
 
     var state = ResponseAccumulator.State.idle
 
-    func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) {
+    func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
         self.state = .head(head)
+        return task.eventLoop.makeSucceededFuture(())
     }
 
     func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {

--- a/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
@@ -27,7 +27,7 @@ class TestHTTPDelegate: HTTPClientResponseDelegate {
         self.state = .head(head)
     }
 
-    func didReceivePart(task: HTTPClient.Task<Response>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
+    func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         switch self.state {
         case .head(let head):
             self.state = .body(head, buffer)
@@ -38,7 +38,7 @@ class TestHTTPDelegate: HTTPClientResponseDelegate {
         default:
             preconditionFailure("expecting head or body")
         }
-        return eventLoop.makeSucceededFuture(())
+        return task.eventLoop.makeSucceededFuture(())
     }
 
     func didFinishRequest(task: HTTPClient.Task<Response>) throws {}
@@ -49,12 +49,12 @@ class CountingDelegate: HTTPClientResponseDelegate {
 
     var count = 0
 
-    func didReceivePart(task: HTTPClient.Task<Response>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
+    func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         let str = buffer.getString(at: 0, length: buffer.readableBytes)
         if str?.starts(with: "id:") ?? false {
             self.count += 1
         }
-        return eventLoop.makeSucceededFuture(())
+        return task.eventLoop.makeSucceededFuture(())
     }
 
     func didFinishRequest(task: HTTPClient.Task<Response>) throws -> Int {

--- a/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
@@ -175,6 +175,7 @@ internal struct HTTPResponseBuilder {
         if var body = body {
             var part = part
             body.writeBuffer(&part)
+            self.body = body
         } else {
             self.body = part
         }

--- a/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
@@ -27,7 +27,7 @@ class TestHTTPDelegate: HTTPClientResponseDelegate {
         self.state = .head(head)
     }
 
-    func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void>? {
+    func didReceivePart(task: HTTPClient.Task<Response>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
         switch self.state {
         case .head(let head):
             self.state = .body(head, buffer)
@@ -38,7 +38,7 @@ class TestHTTPDelegate: HTTPClientResponseDelegate {
         default:
             preconditionFailure("expecting head or body")
         }
-        return nil
+        return eventLoop.makeSucceededFuture(())
     }
 
     func didFinishRequest(task: HTTPClient.Task<Response>) throws {}
@@ -49,13 +49,12 @@ class CountingDelegate: HTTPClientResponseDelegate {
 
     var count = 0
 
-    func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void>? {
-        var buffer = buffer
-        let str = buffer.readString(length: buffer.readableBytes)
+    func didReceivePart(task: HTTPClient.Task<Response>, eventLoop: EventLoop, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
+        let str = buffer.getString(at: 0, length: buffer.readableBytes)
         if str?.starts(with: "id:") ?? false {
             self.count += 1
         }
-        return nil
+        return eventLoop.makeSucceededFuture(())
     }
 
     func didFinishRequest(task: HTTPClient.Task<Response>) throws -> Int {

--- a/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
@@ -27,7 +27,7 @@ class TestHTTPDelegate: HTTPClientResponseDelegate {
         self.state = .head(head)
     }
 
-    func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) {
+    func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void>? {
         switch self.state {
         case .head(let head):
             self.state = .body(head, buffer)
@@ -38,6 +38,7 @@ class TestHTTPDelegate: HTTPClientResponseDelegate {
         default:
             preconditionFailure("expecting head or body")
         }
+        return nil
     }
 
     func didFinishRequest(task: HTTPClient.Task<Response>) throws {}
@@ -48,12 +49,13 @@ class CountingDelegate: HTTPClientResponseDelegate {
 
     var count = 0
 
-    func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) {
+    func didReceivePart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void>? {
         var buffer = buffer
         let str = buffer.readString(length: buffer.readableBytes)
         if str?.starts(with: "id:") ?? false {
             self.count += 1
         }
+        return nil
     }
 
     func didFinishRequest(task: HTTPClient.Task<Response>) throws -> Int {

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests+XCTest.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests+XCTest.swift
@@ -43,6 +43,8 @@ extension SwiftHTTPTests {
             ("testProxyTLS", testProxyTLS),
             ("testUploadStreaming", testUploadStreaming),
             ("testProxyStreaming", testProxyStreaming),
+            ("testProxyStreamingFailure", testProxyStreamingFailure),
+            ("testUploadStreamingBackpressure", testUploadStreamingBackpressure),
         ]
     }
 }

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests+XCTest.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests+XCTest.swift
@@ -41,6 +41,8 @@ extension SwiftHTTPTests {
             ("testCancel", testCancel),
             ("testProxyPlaintext", testProxyPlaintext),
             ("testProxyTLS", testProxyTLS),
+            ("testUploadStreaming", testUploadStreaming),
+            ("testProxyStreaming", testProxyStreaming),
         ]
     }
 }

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
@@ -40,7 +40,7 @@ class SwiftHTTPTests: XCTestCase {
         let channel = EmbeddedChannel()
         let recorder = RecordingHandler<HTTPClientResponsePart, HTTPClientRequestPart>()
         let promise: EventLoopPromise<Void> = channel.eventLoop.makePromise()
-        let task = Task(future: promise.futureResult)
+        let task = Task(eventLoop: channel.eventLoop, future: promise.futureResult)
 
         try channel.pipeline.addHandler(recorder).wait()
         try channel.pipeline.addHandler(TaskHandler(task: task, delegate: TestHTTPDelegate(), promise: promise, redirectHandler: nil)).wait()
@@ -69,7 +69,7 @@ class SwiftHTTPTests: XCTestCase {
         let channel = EmbeddedChannel()
         let delegate = TestHTTPDelegate()
         let promise: EventLoopPromise<Void> = channel.eventLoop.makePromise()
-        let task = Task(future: promise.futureResult)
+        let task = Task(eventLoop: channel.eventLoop, future: promise.futureResult)
         let handler = TaskHandler(task: task, delegate: delegate, promise: promise, redirectHandler: nil)
 
         try channel.pipeline.addHandler(handler).wait()

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
@@ -310,7 +310,7 @@ class SwiftHTTPTests: XCTestCase {
             for _ in 0..<2 {
                 var buffer = allocator.buffer(capacity: 4)
                 buffer.writeString("1234")
-                _ = writer(buffer)
+                _ = writer(.byteBuffer(buffer))
             }
             return httpClient.group.next().makeSucceededFuture(())
         }

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
@@ -326,9 +326,9 @@ class SwiftHTTPTests: XCTestCase {
 
         let body: HTTPClient.Body = .stream(length: 8) { writer in
             let buffer = ByteBuffer.of(string: "1234")
-            return writer(.byteBuffer(buffer)).flatMap {
+            return writer.write(.byteBuffer(buffer)).flatMap {
                 let buffer = ByteBuffer.of(string: "4321")
-                return writer(.byteBuffer(buffer))
+                return writer.write(.byteBuffer(buffer))
             }
         }
 
@@ -354,7 +354,7 @@ class SwiftHTTPTests: XCTestCase {
                 request.headers.add(name: "Accept", value: "text/event-stream")
 
                 let delegate = CopyingDelegate { part in
-                    writer(.byteBuffer(part))
+                    writer.write(.byteBuffer(part))
                 }
                 return httpClient.execute(request: request, delegate: delegate).future
             } catch {

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
@@ -111,10 +111,8 @@ class SwiftHTTPTests: XCTestCase {
         }
 
         let response = try httpClient.post(url: "http://localhost:\(httpBin.port)/post", body: .string("1234")).wait()
-        let bytes = response.body!.withUnsafeReadableBytes {
-            Data(bytes: $0.baseAddress!, count: $0.count)
-        }
-        let data = try JSONDecoder().decode(RequestInfo.self, from: bytes)
+        let bytes = response.body.flatMap { $0.getData(at: 0, length: $0.readableBytes) }
+        let data = try JSONDecoder().decode(RequestInfo.self, from: bytes!)
 
         XCTAssertEqual(.ok, response.status)
         XCTAssertEqual("1234", data.data)
@@ -145,10 +143,8 @@ class SwiftHTTPTests: XCTestCase {
         let request = try Request(url: "https://localhost:\(httpBin.port)/post", method: .POST, body: .string("1234"))
 
         let response = try httpClient.execute(request: request).wait()
-        let bytes = response.body!.withUnsafeReadableBytes {
-            Data(bytes: $0.baseAddress!, count: $0.count)
-        }
-        let data = try JSONDecoder().decode(RequestInfo.self, from: bytes)
+        let bytes = response.body.flatMap { $0.getData(at: 0, length: $0.readableBytes) }
+        let data = try JSONDecoder().decode(RequestInfo.self, from: bytes!)
 
         XCTAssertEqual(.ok, response.status)
         XCTAssertEqual("1234", data.data)
@@ -343,10 +339,8 @@ class SwiftHTTPTests: XCTestCase {
         }
 
         let response = try httpClient.post(url: "http://localhost:\(httpBin.port)/post", body: body).wait()
-        let bytes = response.body!.withUnsafeReadableBytes {
-            Data(bytes: $0.baseAddress!, count: $0.count)
-        }
-        let data = try JSONDecoder().decode(RequestInfo.self, from: bytes)
+        let bytes = response.body.flatMap { $0.getData(at: 0, length: $0.readableBytes) }
+        let data = try JSONDecoder().decode(RequestInfo.self, from: bytes!)
 
         XCTAssertEqual(.ok, response.status)
         XCTAssertEqual("12344321", data.data)
@@ -375,10 +369,8 @@ class SwiftHTTPTests: XCTestCase {
         }
 
         let upload = try! httpClient.post(url: "http://localhost:\(httpBin.port)/post", body: body).wait()
-        let bytes = upload.body!.withUnsafeReadableBytes {
-            Data(bytes: $0.baseAddress!, count: $0.count)
-        }
-        let data = try! JSONDecoder().decode(RequestInfo.self, from: bytes)
+        let bytes = upload.body.flatMap { $0.getData(at: 0, length: $0.readableBytes) }
+        let data = try! JSONDecoder().decode(RequestInfo.self, from: bytes!)
 
         XCTAssertEqual(.ok, upload.status)
         XCTAssertEqual("id: 0id: 1id: 2id: 3id: 4id: 5id: 6id: 7id: 8id: 9", data.data)


### PR DESCRIPTION
Addressing comments in the client proposal discussion, I would like to propose the following change:

`HTTPResponseDelegate.didReceivePart` now returns an optional future that could be used to indicate to the client that reads should be stopped until this future is resolved (backpressure)

`HTTPClient.Body` is now a struct with optional length and a callback for upload streaming. In addition, there are static methods to keep API the same as before.