### PR TITLE
move elg provider as a nested class of the client

### DIFF
--- a/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
+++ b/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
@@ -18,11 +18,6 @@ import NIOConcurrencyHelpers
 import NIOHTTP1
 import NIOSSL
 
-public enum EventLoopGroupProvider {
-    case shared(EventLoopGroup)
-    case createNew
-}
-
 public class HTTPClient {
     public let eventLoopGroup: EventLoopGroup
     let eventLoopGroupProvider: EventLoopGroupProvider
@@ -201,6 +196,11 @@ public class HTTPClient {
         }
     }
 
+    public enum EventLoopGroupProvider {
+        case shared(EventLoopGroup)
+        case createNew
+    }
+    
     public struct Timeout {
         public var connect: TimeAmount?
         public var read: TimeAmount?


### PR DESCRIPTION
motivation: elg provider is a likely to be a common pattern in client libraries (like db drivers etc), lets prevent type clashes

changes: make EventLoopGroupProvider a nested class of HTTPClient