### PR TITLE
Make Task.future public

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,36 +111,36 @@ httpClient.execute(request: request, timeout: timeout)
 ### Streaming
 When dealing with larger amount of data, it's critical to stream the response body instead of aggregating in-memory. Handling a response stream is done using a delegate protocol. The following example demonstrates how to count the number of bytes in a streaming response body:
 ```swift
-class CountingDelegate: HTTPResponseDelegate {
+class CountingDelegate: HTTPClientResponseDelegate {
     typealias Response = Int
 
     var count = 0
 
-    func didTransmitRequestBody() {
+    func didTransmitRequestBody(task: HTTPClient.Task<Int>) {
         // this is executed when request is sent, called once
     }
 
-    func didReceiveHead(_ head: HTTPResponseHead) {
+    func didReceiveHead(task: HTTPClient.Task<Int>, _ head: HTTPResponseHead) {
         // this is executed when we receive HTTP Reponse head part of the request (it contains response code and headers), called once
     }
 
-    func didReceivePart(_ buffer: ByteBuffer) {
+    func didReceivePart(task: HTTPClient.Task<Int>, _ buffer: ByteBuffer) {
         // this is executed when we receive parts of the response body, could be called zero or more times
         count += buffer.readableBytes
     }
 
-    func didFinishRequest() throws -> Int {
+    func didFinishRequest(task: HTTPClient.Task<Int>) throws -> Int {
         // this is called when the request is fully read, called once
         // this is where you return a result or throw any errors you require to propagate to the client
         return count
     }
 
-    func didReceiveError(_ error: Error) {
+    func didReceiveError(task: HTTPClient.Task<Int>, _ error: Error) {
         // this is called when we receive any network-related error, called once
     }
 }
 
-let request = try HTTPRequest(url: "https://swift.org")
+let request = try HTTPClient.Request(url: "https://swift.org")
 let delegate = CountingDelegate()
 
 try httpClient.execute(request: request, delegate: delegate).future.whenSuccess { count in

--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -207,7 +207,7 @@ internal extension URL {
 
 public extension HTTPClient {
     final class Task<Response> {
-        let future: EventLoopFuture<Response>
+        public let future: EventLoopFuture<Response>
 
         private var channel: Channel?
         private var cancelled: Bool
@@ -226,10 +226,6 @@ public extension HTTPClient {
             }
         }
 
-        public func wait() throws -> Response {
-            return try self.future.wait()
-        }
-
         public func cancel() {
             self.lock.withLock {
                 if !cancelled {
@@ -237,10 +233,6 @@ public extension HTTPClient {
                     channel?.pipeline.fireUserInboundEventTriggered(TaskCancelEvent())
                 }
             }
-        }
-
-        public func cascade(promise: EventLoopPromise<Response>) {
-            self.future.cascade(to: promise)
         }
     }
 }
@@ -484,6 +476,6 @@ internal struct RedirectHandler<T> {
             request.headers.remove(name: "Proxy-Authorization")
         }
 
-        return self.execute(request).cascade(promise: promise)
+        return self.execute(request).future.cascade(to: promise)
     }
 }

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
@@ -231,7 +231,7 @@ class SwiftHTTPTests: XCTestCase {
         request.headers.add(name: "Accept", value: "text/event-stream")
 
         let delegate = CountingDelegate()
-        let count = try httpClient.execute(request: request, delegate: delegate).wait()
+        let count = try httpClient.execute(request: request, delegate: delegate).future.wait()
 
         XCTAssertEqual(10, count)
     }
@@ -285,7 +285,7 @@ class SwiftHTTPTests: XCTestCase {
             task.cancel()
         }
 
-        XCTAssertThrowsError(try task.wait(), "Should fail") { error in
+        XCTAssertThrowsError(try task.future.wait(), "Should fail") { error in
             guard case let error = error as? HTTPClientError, error == .cancelled else {
                 return XCTFail("Should fail with cancelled")
             }


### PR DESCRIPTION
When trying to implement the README example for streaming, there were a few compile warnings.

- `HTTPResponseDelegate` has been renamed to `HTTPClientResponseDelegate`
- The protocol functions now have a `task` parameter
- `HTTPRequest` has been renamed `HTTPClient.Request`
- `httpClient.execute(request:, delegate:).future` is inaccessible since future is internal.

This pull requests fixes these issues in the Readme example. 

This includes making `Task.future` public. Since future is now public, I removed `wait` and `cascade` since they are now available on the future. This would be a breaking change and existing code in the project has been updated to reflect the change.

I have two remaining questions, was there a reason why `Task.future` was originally made internal and is the README example for accessing the streaming result correct?

