### PR TITLE
feat: Add support for percent encoded requests

### DIFF
--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -228,7 +228,8 @@ extension HTTPClientResponseDelegate {
 
 internal extension URL {
     var uri: String {
-        return path.isEmpty ? "/" : path + (query.map { "?" + $0 } ?? "")
+        let urlEncodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        return path.isEmpty ? "/" : urlEncodedPath + (query.map { "?" + $0 } ?? "")
     }
 
     func hasTheSameOrigin(as other: URL) -> Bool {

--- a/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
@@ -246,6 +246,14 @@ internal final class HttpBinHandler: ChannelInboundHandler {
                 headers.add(name: "Location", value: "http://127.0.0.1:\(port)/echohostheader")
                 self.resps.append(HTTPResponseBuilder(status: .found, headers: headers))
                 return
+            // Since this String is taken from URL.path, the percent encoding has been removed
+            case "/percent encoded":
+                if req.method != .GET {
+                    self.resps.append(HTTPResponseBuilder(status: .methodNotAllowed))
+                    return
+                }
+                self.resps.append(HTTPResponseBuilder(status: .ok))
+                return
             case "/echohostheader":
                 var builder = HTTPResponseBuilder(status: .ok)
                 let hostValue = req.headers["Host"].first ?? ""

--- a/Tests/NIOHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -32,6 +32,7 @@ extension HTTPClientTests {
             ("testPostHttps", testPostHttps),
             ("testHttpRedirect", testHttpRedirect),
             ("testHttpHostRedirect", testHttpHostRedirect),
+            ("testPercentEncoded", testPercentEncoded),
             ("testMultipleContentLengthHeaders", testMultipleContentLengthHeaders),
             ("testStreaming", testStreaming),
             ("testRemoteClose", testRemoteClose),

--- a/Tests/NIOHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTests.swift
@@ -135,6 +135,18 @@ class HTTPClientTests: XCTestCase {
         let hostName = try decoder.decode([String: String].self, from: responseData)["data"]
         XCTAssert(hostName == "127.0.0.1")
     }
+    
+    func testPercentEncoded() throws {
+        let httpBin = HttpBin()
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            try! httpClient.syncShutdown()
+            httpBin.shutdown()
+        }
+        
+        let response = try httpClient.get(url: "http://localhost:\(httpBin.port)/percent%20encoded").wait()
+        XCTAssertEqual(.ok, response.status)
+    }
 
     func testMultipleContentLengthHeaders() throws {
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)


### PR DESCRIPTION
This is a fix for issue #42

Previously when you made HTTP requests to a route with percent encoding, the encoding would be removed causing the request to fail. 

This request adds the percent encoding back to the path when you get the uri so that it can be correctly processed. 